### PR TITLE
0.4.1

### DIFF
--- a/src/lib/components/form/Form.svelte
+++ b/src/lib/components/form/Form.svelte
@@ -160,7 +160,7 @@
           easing: quintOut,
         }}
       >
-        {#if input.type === "text" || input.type === "email" || input.type === "password" || input.type === "date" || input.type === "number" || input.type === "textarea" || input.type === "tel" || input.type === "phone"}
+        {#if input.type === "text" || input.type === "email" || input.type === "password" || input.type === "date" || input.type === "number" || input.type === "textarea" || input.type === "tel" || input.type === "phone" || input.type === "time"}
           <Input {...input} bind:value={input.value} />
         {/if}
 

--- a/src/lib/components/input/Input.svelte
+++ b/src/lib/components/input/Input.svelte
@@ -47,6 +47,16 @@
     }
   }
 
+  function timeFieldFocused(event) {
+    event.currentTarget.type = "time";
+  }
+
+  function timeFieldBlurred(event) {
+    if (!event.currentTarget.value) {
+      event.currentTarget.type = "text";
+    }
+  }
+
   function typeaheadOnInput(event) {
     const value = event.target.value;
 
@@ -344,6 +354,31 @@
       {/if}
     </div>
   </div>
+{:else if type === "time"}
+  <div class="form__field__container" {id} class:mb-2={margin}>
+    <div class="field" class:active={focused || value || value === 0 || value === "0"}>
+      <div class="field__label">
+        <span class:hidden={is_error}>{_label}</span>
+        <span class="error hidden" class:hidden={!is_error}>{error}</span>
+      </div>
+      <div class="field__wrap">
+        <input
+          class="field__input"
+          class:error={is_error}
+          autocomplete={autocomplete ? "on" : "nope"}
+          type="text"
+          bind:value
+          on:focus={inputFocused}
+          on:focus={timeFieldFocused}
+          on:blur={inputBlurred}
+          on:blur={timeFieldBlurred}
+        />
+      </div>
+      {#if desc}
+        <p class="field__desc">{@html desc}</p>
+      {/if}
+    </div>
+  </div>
 {:else if type === "textarea"}
   <div class="form__field__container" {id} class:mb-2={margin}>
     <div class="field" class:active={focused || value || value === 0 || value === "0"}>
@@ -435,6 +470,10 @@
   input::-webkit-inner-spin-button {
     -webkit-appearance: none;
     margin: 0;
+  }
+  :global(input[type="time"]::-webkit-calendar-picker-indicator) {
+    background: none;
+    display: none;
   }
 
   input[type="number"] {

--- a/src/lib/components/table/TableCell.svelte
+++ b/src/lib/components/table/TableCell.svelte
@@ -56,7 +56,7 @@
     <div class="flex align-items-center">
       {#if href}
         <span class="href-container">
-          {#if $navigating && $navigating?.to?.path === href}
+          {#if $navigating && $navigating?.to?.pathname === href}
             <Spinner style="margin: 0 0.5rem 0 0" />
           {/if}
           <a class:h6={large} class:bold sveltekit:prefetch {href}>{text}</a>
@@ -129,7 +129,12 @@
 {/if}
 
 {#if _type === "button" && !$pageStore.is_mobile}
-  <div class="cell right" class:mobile__hide={mobile_hide} {style}>
+  <div
+    class="cell right"
+    class:mobile__hide={mobile_hide}
+    {style}
+    class:__clickable={button.icon === "arrowRight" || !button.icon}
+  >
     <IconButton icon="arrowRight" {...button} />
   </div>
 {/if}

--- a/src/lib/components/table/TableRow.svelte
+++ b/src/lib/components/table/TableRow.svelte
@@ -21,7 +21,11 @@
   <div class="row" class:cursor-pointer={onclick} on:click={onclick} {id}>
     {#if cells && cells.length}
       {#each cells as cell}
-        <TableCell {...cell} />
+        {#if cell.button}
+          <TableCell {...cell} />
+        {:else}
+          <TableCell {...cell} />
+        {/if}
       {/each}
     {:else}
       <slot><TableCell><p>--</p></TableCell></slot>
@@ -42,10 +46,10 @@
     border-bottom: none !important;
   }
 
-  /* :global(a.row:hover button) {
-    -webkit-box-shadow: 0 5px 20px rgba(227, 230, 236, 0.85);
-    box-shadow: 0 5px 20px rgba(227, 230, 236, 0.85);
-  } */
+  :global(.row:hover .__clickable button) {
+    -webkit-box-shadow: 0 5px 0.625rem rgba(227, 230, 236, 0.6);
+    box-shadow: 0 5px 0.625rem rgba(227, 230, 236, 0.6);
+  }
 
   @media only screen and (max-width: 767px) {
     .row {

--- a/src/lib/utils/url.js
+++ b/src/lib/utils/url.js
@@ -75,7 +75,7 @@ const addQueryParam = (key, value, options = { goto: false, show_loading: "", ke
 
 /**
  * Will return an object with all of the query parameters for a url. Works on server and client
- * @param {Object} page - pass the svelte kit page store
+ * @param {Object} url - pass the svelte kit url object found on the load function or $page.url
  * @param {String} [key=null] - if you pass a key, you'll get the query param for that key
  * @returns {String|Object} - If you pass in a key, the return will be the value of the param. Without a key, an Object is returned for all of the query params
  */

--- a/src/misc/changelog/0.4.1.md
+++ b/src/misc/changelog/0.4.1.md
@@ -1,0 +1,17 @@
+---
+component: v-0.4.1
+title: "Version 0.4.1"
+date: "4 January 2022"
+---
+
+**Added**
+
+- Time inputs
+
+**Fixed**
+
+- Fixed JSDoc comments on url utils
+- Removed console logs from examples
+- `arrowRight` will now show hover state when table has an href or onclick function
+- Fixed loading indicators on `Sidebar` and `IconButton` as result of Svelte kit naming updates
+- Sidebar will now show the active indicator on the highest matched path.

--- a/src/misc/sections/components/Input.svelte
+++ b/src/misc/sections/components/Input.svelte
@@ -87,6 +87,10 @@
             <TableCell>This will render a number input.</TableCell>
           </TableRow>
           <TableRow>
+            <TableCell><span style="font-weight: 700"><code>time</code></span></TableCell>
+            <TableCell>This will render a time input.</TableCell>
+          </TableRow>
+          <TableRow>
             <TableCell><span style="font-weight: 700"><code>textarea</code></span></TableCell>
             <TableCell>This will render a textarea element.</TableCell>
           </TableRow>
@@ -259,6 +263,16 @@
             error="Enter your phone number"
             validation="required"
             desc="Enter your phone number. If your country code is not +1, enter your country code first."
+            margin={true}
+          />
+
+          <Input
+            id="time"
+            type="time"
+            label="Enter a time"
+            error="Enter a time"
+            validation="string"
+            desc="Enter a time. When a form is submitted, time is submitted as a string from '0:00 to 23:59'"
             margin={true}
           />
 

--- a/src/routes/examples/__layout.reset.svelte
+++ b/src/routes/examples/__layout.reset.svelte
@@ -44,6 +44,7 @@
         label: "Form",
         href: "/examples/form",
         icon: "/favicon.png",
+        href_aliases: ["/examples/test"],
       },
     ],
   };

--- a/src/routes/examples/form/index.svelte
+++ b/src/routes/examples/form/index.svelte
@@ -1,3 +1,27 @@
+<!-- <script context="module">
+  const promise = () => {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        resolve();
+      }, 3000);
+    });
+  };
+
+  export async function load({ url, params, fetch, session, stuff }) {
+    console.log("loading...");
+    await promise();
+
+    return {
+      props: {
+        data: true,
+      },
+    };
+  }
+</script> -->
+<script context="module">
+  export const prerender = true;
+</script>
+
 <script>
   import Section from "$misc/components/section.svelte";
 
@@ -22,6 +46,32 @@
       type: "hidden",
       id: "hidden_input_id",
       value: "Hello World",
+    },
+    {
+      type: "time", //will render a text input field. Other options are: "email" and "password" which are all basically the same thing
+      id: "time.open", //the id will be the key when you call the getFormData function. If you add a "." in the id, it will return the item as a nested object. For example, if your `id` value is `name.last`, the getFormData function will return that as {name: {last: ""}}
+      label: "Open", //The label is what we'll initially show for the input, it should explain what is required. Keep this short like "First Name"
+      value: null, //You can add a value to the input
+      desc: "You'll be able to change this name later", //This will add text below the input to explain in more detail what is needed from the user. Optional.
+      error: "A name is required", //this is the text that will appear if this input fails validation
+      validation: "string|required|min:3", // See the validation section for more details, but this adds what validation you need. In This case, it must be a string, it's required, with a min length of 3
+      validate_on_blur: true, //defaults to true. Will run validation when focus is lost from the element
+      vob: true, //defaults to true. Alias validation_on_blur just less to type. You only need to set one.
+      value: "Jamie",
+      width: 50,
+    },
+    {
+      type: "time", //will render a text input field. Other options are: "email" and "password" which are all basically the same thing
+      id: "time.close", //the id will be the key when you call the getFormData function. If you add a "." in the id, it will return the item as a nested object. For example, if your `id` value is `name.last`, the getFormData function will return that as {name: {last: ""}}
+      label: "Close", //The label is what we'll initially show for the input, it should explain what is required. Keep this short like "First Name"
+      value: null, //You can add a value to the input
+      desc: "You'll be able to change this name later", //This will add text below the input to explain in more detail what is needed from the user. Optional.
+      error: "A name is required", //this is the text that will appear if this input fails validation
+      validation: "string|required|min:3", // See the validation section for more details, but this adds what validation you need. In This case, it must be a string, it's required, with a min length of 3
+      validate_on_blur: true, //defaults to true. Will run validation when focus is lost from the element
+      vob: true, //defaults to true. Alias validation_on_blur just less to type. You only need to set one.
+      value: "Jones",
+      width: 50,
     },
     {
       type: "text", //will render a text input field. Other options are: "email" and "password" which are all basically the same thing

--- a/src/routes/examples/pokedex/index.svelte
+++ b/src/routes/examples/pokedex/index.svelte
@@ -121,11 +121,6 @@
   import Column100 from "$lib/layouts/Column100.svelte";
   import ListItem from "$lib/components/list/ListItem.svelte";
   import ListItemTimeline from "$lib/components/list/ListItemTimeline.svelte";
-  import { getQueryParam } from "$lib/utils/url";
-  import { page } from "$app/stores";
-
-  console.log($page);
-  console.log(getQueryParam($page.url));
 
   const types = [
     "All",

--- a/src/routes/examples/settings/index.svelte
+++ b/src/routes/examples/settings/index.svelte
@@ -21,10 +21,6 @@
   import ListItem from "$lib/components/list/ListItem.svelte";
   import ListItemTimeline from "$lib/components/list/ListItemTimeline.svelte";
   import { pageStore } from "$lib/stores/stores";
-
-  const icon1 = uuid();
-  const icon2 = uuid();
-  const icon3 = uuid();
 </script>
 
 <Header title="Settings" breadcrumbs={false} />
@@ -33,22 +29,22 @@
   <Column100>
     <Card>
       <Table>
-        <TableRow href="/examples/pokedex" onclick={() => ($pageStore.clicked = icon1)}>
+        <TableRow href="/examples/pokedex">
           <TableCell text="Profile" large={true} bold={true} caption="Edit your profile and update your photo" />
-          <TableCell button={{ icon: "arrowRight", href: "/examples/pokedex", id: icon1 }} />
+          <TableCell button={{ icon: "arrowRight", href: "/examples/pokedex" }} />
         </TableRow>
-        <TableRow href="/examples/pokedex" onclick={() => ($pageStore.clicked = icon2)}>
+        <TableRow href="/examples/pokedex">
           <TableCell text="Notifications" large={true} caption="Select how and went we message you" />
-          <TableCell button={{ icon: "arrowRight", href: "/examples/pokedex", id: icon2 }} />
+          <TableCell button={{ icon: "arrowRight", href: "/examples/pokedex" }} />
         </TableRow>
-        <TableRow href="/examples/pokedex" onclick={() => ($pageStore.clicked = icon3)}>
+        <TableRow href="/examples/pokedex">
           <TableCell
             text="Billing"
             large={true}
             bold={true}
             caption="Edit your payment methods and see past transactions"
           />
-          <TableCell button={{ icon: "arrowRight", href: "/examples/pokedex", id: icon3 }} />
+          <TableCell button={{ icon: "arrowRight", href: "/examples/pokedex" }} />
         </TableRow>
       </Table>
     </Card>


### PR DESCRIPTION
Closes #63, Closes #61, Closes #58 

- Time inputs
- Fixed JSDoc comments on url utils
- Removed console logs from examples
- `arrowRight` will now show hover state when table has an href or onclick function
- Fixed loading indicators on `Sidebar` and `IconButton` as result of Svelte kit naming updates
- Sidebar will now show the active indicator on the highest matched path.